### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,8 @@
 name: Integration
 
 on:
+  pull_request:
+    types: [synchronize]
   push: {}
   schedule:
     - cron: "0 5 * * *"


### PR DESCRIPTION
I believe these changes will make CI run on commits to pull requests - allowing us to check that the tests pass before merging.