### PR TITLE
Update package set

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -1,25 +1,23 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200909/packages.dhall sha256:b899488adf6f02a92bbaae88039935bbc61bcba4cf4462f6d915fc3d0e094604
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200922/packages.dhall sha256:5edc9af74593eab8834d7e324e5868a3d258bbab75c5531d2eb770d4324a2900
 
 in  upstream
   with versions =
     { dependencies =
-        [ "console"
-        , "control"
-        , "either"
-        , "exceptions"
-        , "foldable-traversable"
-        , "functions"
-        , "integers"
-        , "lists"
-        , "maybe"
-        , "orders"
-        , "parsing"
-        , "partial"
-        , "strings"
-        ]
-    , repo =
-        "https://github.com/hdgarrood/purescript-versions.git"
-    , version =
-        "v5.0.1"
+      [ "console"
+      , "control"
+      , "either"
+      , "exceptions"
+      , "foldable-traversable"
+      , "functions"
+      , "integers"
+      , "lists"
+      , "maybe"
+      , "orders"
+      , "parsing"
+      , "partial"
+      , "strings"
+      ]
+    , repo = "https://github.com/hdgarrood/purescript-versions.git"
+    , version = "v5.0.1"
     }


### PR DESCRIPTION
The [v0.2.0 release of github-actions-toolkit](https://github.com/purescript-contrib/purescript-github-actions-toolkit/releases/tag/v0.2.0) fixes an issue with the `find` function in the FFI, which caused a problem in this project as well when attempting to find a tool. Updating the package set pulls in the new version.