### PR TITLE
Update latest version for spago to 1.0.4

### DIFF
--- a/dist/versions-v2.json
+++ b/dist/versions-v2.json
@@ -5,7 +5,7 @@
   },
   "spago": {
     "unstable": "0.93.44",
-    "latest": "0.21.0"
+    "latest": "1.0.4"
   },
   "psa": {
     "unstable": "0.9.0",


### PR DESCRIPTION
The latest spago version is 1.0.4:

https://www.npmjs.com/package/spago?activeTab=versions